### PR TITLE
Fix werkzeug dependency versie compatibiliteitsprobleem

### DIFF
--- a/claude.txt
+++ b/claude.txt
@@ -98,7 +98,7 @@ De applicatie volgt een modulaire structuur met de volgende hoofdcomponenten:
 - **Afhankelijkheid**: Geen afhankelijkheden
 
 ### requirements.txt
-- **Status**: Volledig geïmplementeerd
+- **Status**: Volledig geïmplementeerd en bijgewerkt
 - **Bestandsnaam**: requirements.txt
-- **Functionaliteit**: Lijst van Python-afhankelijkheden voor de applicatie
+- **Functionaliteit**: Lijst van Python-afhankelijkheden voor de applicatie, inclusief specifieke versies voor Flask en Werkzeug om compatibiliteitsproblemen te voorkomen
 - **Afhankelijkheid**: Geen afhankelijkheden

--- a/claude_steps.txt
+++ b/claude_steps.txt
@@ -38,6 +38,10 @@
    - Gebruiksinstructies
    - Instructies voor virtuele omgeving (venv) toegevoegd
 
+7. **Dependency versies oplossen** ✅
+   - Werkzeug versie gefixeerd op 2.2.3 om compatibiliteit met Flask 2.2.3 te garanderen
+   - Opgelost importfout met url_quote functie
+
 ## Nice-to-have stappen
 
 1. **Admin interface voor app-beheer** 🔄
@@ -70,4 +74,4 @@
 
 Alle must-have stappen zijn nu afgerond. De volgende stappen zijn nice-to-have uitbreidingen die de functionaliteit en gebruikerservaring kunnen verbeteren, maar niet noodzakelijk zijn voor de basiswerking van de applicatie. De applicatie heeft nu alle essentiële functionaliteit voor productief gebruik.
 
-De huidige prioriteit is het mergen van pull request #10 voor het configuratiesysteem. Daarna kan begonnen worden met de implementatie van de admin interface voor app-beheer (issue #12 en gerelateerde PR #15), wat de eerste nice-to-have feature is om te implementeren.
+De huidige prioriteit is het mergen van pull request #19 voor het oplossen van het werkzeug dependency probleem. Daarna kan begonnen worden met de implementatie van de admin interface voor app-beheer (issue #12 en gerelateerde PR #15), wat de eerste nice-to-have feature is om te implementeren.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.0
 requests==2.28.2
 oauthlib==3.2.2
 pyOpenSSL==23.1.1
+werkzeug==2.2.3


### PR DESCRIPTION
## Beschrijving
Deze pull request lost het probleem op dat gemeld is in issue #18 waarbij de app niet kon starten vanwege een importfout:
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```

## Oorzaak
Het probleem wordt veroorzaakt door een incompatibele versie van de werkzeug bibliotheek. Flask 2.2.3 vereist werkzeug 2.2.x, maar er was waarschijnlijk een nieuwere versie geïnstalleerd die de `url_quote` functie niet meer bevat of deze functie is verplaatst.

## Oplossing
- Werkzeug versie 2.2.3 specifiek toegevoegd aan requirements.txt om ervoor te zorgen dat de juiste versie wordt geïnstalleerd die compatibel is met Flask 2.2.3

## Tests uitgevoerd
- Handmatige test: Controleren of de applicatie succesvol start met de gespecificeerde werkzeug versie

## Closes
Sluit issue #18