### PR TITLE
Fix 'now' function undefined error in templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,11 @@ def _jinja2_filter_now(format_=None):
     """Jinja filter voor de huidige datum/tijd."""
     return datetime.datetime.now()
 
+# Maak 'now' functie beschikbaar in templates
+@app.context_processor
+def inject_now():
+    return {'now': datetime.datetime.now}
+
 @app.route('/')
 @auth.require_login
 def index():


### PR DESCRIPTION
## Beschrijving
Deze pull request lost het probleem op dat wordt beschreven in issue #20, waarbij de `now()` functie in de Jinja2 templates als undefined wordt beschouwd.

## Analyse
Het probleem trad op omdat de Jinja2 template `{{ now().year }}` probeert te gebruiken in de footer van base.html, maar de 'now' functie was niet beschikbaar in de template context.

## Wijzigingen
- Toegevoegd: `inject_now` context processor aan app.py om de datetime.datetime.now functie beschikbaar te maken in alle templates
- Bestaande template filter behouden voor backward compatibility

## Tests uitgevoerd
- Handmatige test: De toepassing start zonder fouten
- Handmatige test: De login pagina laadt correct met copyright jaar in de footer
- Handmatige test: De hoofdpagina toont het juiste jaar in de footer

## Closes
Sluit issue #20