### PR TITLE
Fix: InsecureTransportError in development omgeving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,15 +2,22 @@
 # Kopieer dit bestand naar .env en vul de waarden in
 
 # Flask configuratie
+# Gebruik 'development' voor lokale ontwikkeling (schakelt HTTPS vereiste uit voor OAuth)
+# Gebruik 'production' voor productieomgeving (HTTPS vereist voor OAuth)
 FLASK_ENV=development
 SECRET_KEY=your-secret-key-change-in-production
 
 # Google OAuth configuratie
+# Verkrijg deze van de Google Cloud Console: https://console.cloud.google.com/
+# Zorg dat je de juiste redirect URI's hebt geconfigureerd:
+# - Lokaal: http://localhost:5000/login/google/callback
+# - Productie: https://jouw-domein.com/login/google/callback
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # Admin configuratie
 # Meerdere admin e-mails kunnen worden toegevoegd, gescheiden door komma's
+# Alleen deze e-mailadressen hebben toegang tot het admin dashboard
 ADMIN_EMAILS=admin@lynxx.com,management@lynxx.com
 
 # Server configuratie

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Je terminal prompt zou nu moeten veranderen, wat aangeeft dat je virtuele omgevi
    GOOGLE_CLIENT_ID=jouw_google_client_id
    GOOGLE_CLIENT_SECRET=jouw_google_client_secret
    ADMIN_EMAILS=admin1@lynxx.com,admin2@lynxx.com
+   FLASK_ENV=development  # Gebruik 'development' voor lokale ontwikkeling, 'production' voor productie
    ```
 
 6. Start de applicatie:
@@ -132,6 +133,27 @@ Applicaties worden geconfigureerd in het `apps.json` bestand. Je kunt apps toevo
 }
 ```
 
+### Google OAuth configuratie
+
+1. Ga naar [Google Cloud Console](https://console.cloud.google.com/)
+2. Maak een nieuw project of selecteer een bestaand project
+3. Ga naar "APIs & Services" > "Credentials"
+4. Klik op "Create Credentials" > "OAuth client ID"
+5. Selecteer "Web application" als applicatietype
+6. Voeg de geautoriseerde redirect URIs toe:
+   - Voor lokale ontwikkeling: `http://localhost:5000/login/google/callback`
+   - Voor productie: `https://jouw-domein.com/login/google/callback`
+7. Kopieer de Client ID en Client Secret naar je `.env` bestand
+
+### HTTPS vereisten en ontwikkelomgeving
+
+OAuth 2.0 vereist standaard HTTPS voor veilige communicatie. In de code wordt dit automatisch afgehandeld:
+
+- **Ontwikkelomgeving**: Als `FLASK_ENV=development` is ingesteld, wordt HTTPS verificatie automatisch uitgeschakeld via de `OAUTHLIB_INSECURE_TRANSPORT=1` omgevingsvariabele zodat je lokaal kunt ontwikkelen zonder HTTPS.
+- **Productieomgeving**: In productie moet je HTTPS gebruiken. Zorg ervoor dat je server correct is geconfigureerd met SSL/TLS certificaten.
+
+> **Let op**: In productie moet `FLASK_ENV` worden ingesteld op `production` of worden weggelaten om de HTTPS-vereisten te behouden!
+
 ### Omgevingsvariabelen
 
 | Variabele | Beschrijving | Voorbeeld |
@@ -140,6 +162,7 @@ Applicaties worden geconfigureerd in het `apps.json` bestand. Je kunt apps toevo
 | GOOGLE_CLIENT_ID | Google OAuth client ID | `123456789.apps.googleusercontent.com` |
 | GOOGLE_CLIENT_SECRET | Google OAuth client secret | `ABCdef123456` |
 | ADMIN_EMAILS | Komma-gescheiden lijst van admin emails | `admin@lynxx.com,manager@lynxx.com` |
+| FLASK_ENV | Omgeving (development/production) | `development` |
 | LOG_LEVEL | Logging niveau | `INFO` |
 
 ## 🏗️ Projectstructuur
@@ -164,6 +187,7 @@ LynxxBusinessPortal/
     ├── base.html           # Basis template
     ├── index.html          # Homepage met app-tegels
     ├── login.html          # Login pagina
+    ├── admin.html          # Admin dashboard
     └── error.html          # Error pagina
 ```
 
@@ -195,7 +219,6 @@ Handmatige tests:
 
 ## 📋 Toekomstige uitbreidingen
 
-- Admin interface voor app-beheer
 - Personalisatie-opties voor gebruikers
 - Zoekfunctionaliteit voor apps
 - Gebruiksstatistieken dashboard

--- a/auth.py
+++ b/auth.py
@@ -11,10 +11,14 @@ Het implementeert Google OAuth voor authenticatie met @lynxx.com accounts.
 import os
 import functools
 import json
-from flask import redirect, request, url_for, session, flash, abort
+from flask import redirect, request, url_for, session, flash, abort, current_app
 import requests
 from oauthlib.oauth2 import WebApplicationClient
 from config import Config
+
+# Schakel HTTPS-verificatie uit voor development
+if os.environ.get('FLASK_ENV') == 'development':
+    os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
 # OAuth Client setup
 client = WebApplicationClient(Config.GOOGLE_CLIENT_ID)
@@ -52,7 +56,7 @@ def oauth_login():
     # Use the client to construct the request URL
     request_uri = client.prepare_request_uri(
         authorization_endpoint,
-        redirect_uri=request.base_url + "/callback",
+        redirect_uri=url_for('google_callback', _external=True),
         scope=["openid", "email", "profile"],
     )
     
@@ -86,7 +90,7 @@ def oauth_callback():
     token_url, headers, body = client.prepare_token_request(
         token_endpoint,
         authorization_response=request.url,
-        redirect_url=request.base_url,
+        redirect_url=url_for('google_callback', _external=True),
         code=code
     )
     


### PR DESCRIPTION
## Beschrijving
Deze pull request lost de `InsecureTransportError` op die optreedt na het klikken op de login button in de ontwikkelomgeving (Issue #30).

## Probleem
In lokale ontwikkelomgevingen vereist OAuth2 standaard HTTPS, maar de applicatie draait lokaal meestal op HTTP. Dit veroorzaakt een `InsecureTransportError` bij het authenticeren.

## Oplossing
1. De `OAUTHLIB_INSECURE_TRANSPORT=1` omgevingsvariabele wordt nu automatisch ingesteld in auth.py als `FLASK_ENV=development` is, waardoor HTTP is toegestaan voor OAuth in ontwikkelomgevingen.
2. Gebruik van `url_for()` met `_external=True` voor het genereren van callback URLs is consistent gemaakt.
3. Documentatie in README.md en .env.example is bijgewerkt met duidelijke instructies voor zowel ontwikkel- als productieomgevingen.

## Wijzigingen
- Verbeterde `auth.py` met automatische detectie voor development/production omgeving
- Bijgewerkte README.md met gedetailleerde instructies voor OAuth configuratie en HTTPS vereisten
- Verbeterd .env.example bestand met commentaar over omgevingsinstellingen

## Tests
- Getest in lokale ontwikkelomgeving: De Google OAuth flow werkt nu correct zonder HTTPS vereiste

## Closes
- Sluit issue #30