### PR TITLE
Navigatie van Admin dashboard naar hoofdpagina

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -67,6 +67,16 @@
         color: white;
     }
     
+    .btn-success {
+        background-color: #28a745;
+        color: white;
+    }
+    
+    .home-link {
+        margin-bottom: 20px;
+        display: inline-block;
+    }
+    
     .app-list {
         list-style: none;
         padding: 0;
@@ -157,6 +167,7 @@
     <div class="admin-section">
         <h1 class="admin-title">Admin Dashboard</h1>
         <p>Welkom bij het admin dashboard. Hier kun je apps beheren in de Lynxx Business Portal.</p>
+        <a href="{{ url_for('index') }}" class="btn btn-success home-link">Terug naar hoofdpagina</a>
     </div>
     
     <div id="notifications"></div>


### PR DESCRIPTION
Deze PR voegt een "Terug naar hoofdpagina" knop toe aan het Admin dashboard, zodat gebruikers eenvoudig kunnen navigeren tussen de admin-interface en de hoofdpagina.

Wijzigingen:
- Nieuwe "Terug naar hoofdpagina" knop toegevoegd aan het begin van de admin interface
- CSS-stijl voor de knop toegevoegd (btn-success)
- Extra styling voor de knop om het er goed uit te laten zien (.home-link)

Dit lost issue #41 op.
